### PR TITLE
minor tweak to chef url

### DIFF
--- a/definitions/python_build.rb
+++ b/definitions/python_build.rb
@@ -8,7 +8,7 @@ define :python_build, :action => :build, :install_prefix => '/usr/local', :owner
   if node["python_build"]["archive_url_base"]
     archive_src = "#{node["python_build"]["archive_url_base"]}/#{archive_file}"
   else
-    archive_src = "http://www.python.org/ftp/python/#{version}/#{archive_file}"
+    archive_src = "https://www.python.org/ftp/python/#{version}/#{archive_file}"
   end
 
   install_prefix = params[:install_prefix]


### PR DESCRIPTION
Hello, I currently use your chef python build and noticed the builds stopped working after the URL location was changed to https.  Let me know if this helps, or need me to patch up additional work.

Thanks!
